### PR TITLE
Fix url redirect rule and spec of activities

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -11,10 +11,10 @@ class ActivitiesController < ApplicationController
   protected
 
   def find_activity
-    @activity = begin
-                  Activity.find_by(permalink: params[:id])
-                rescue ActiveRecord::RecordNotFound
-                  Activity.find(params[:id])
-                end
+    @activity = Activity.find_by(permalink: params[:id])
+    if @activity.nil? && activity = Activity.find(params[:id])
+      redirect_to activity_path(activity)
+      return false
+    end
   end
 end

--- a/spec/requests/activities_spec.rb
+++ b/spec/requests/activities_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe "Activities", type: :request do
 
   end
 
+  describe "GET /activities/:id but only id" do
+
+    let! :activity do
+      FactoryGirl.create(:activity)
+    end
+
+    it "should redirect if only use id in id param" do
+      get "/activities/#{activity.id}"
+      expect(response).to redirect_to(activity_url(activity))
+    end
+
+  end
+
   describe "GET /activities/:id" do
 
     let! :activity do


### PR DESCRIPTION
Fix url redirect rule and spec of activities, redirect `/activities/:id` to `/activities/:permalink`
