### PR TITLE
Ignore withdrawn papers display on activity page, Closed #29

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -28,6 +28,7 @@ class Paper < ApplicationRecord
   acts_as_taggable_on :tags
 
   scope :state, -> (state) { where(state: state) }
+  scope :opened, -> { where.not(state: :withdrawn)}
 
   aasm(column: :state) do
     state :submitted , initial: true

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -15,5 +15,5 @@
           p.date
             span.date #{activity.open_at.to_date} ~ #{activity.close_at.to_date}
           p.count
-            = link_to pluralize(activity.papers_count, 'proposal'), activity
+            = link_to pluralize(activity.papers.opened.size, 'proposal'), activity
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -59,5 +59,16 @@ RSpec.describe Activity, type: :model do
     it "should able to find unreview papers by specify user" do
       expect(activity.unreview_by(user).size).to eq(@unreview_papers.size)
     end
+
+    context "public display" do
+      it "ignore withdraw papaer" do
+        opended_papers = @unreview_papers.size +
+                         @reviewed_papers.size +
+                         1                     + # Unreview Accepted Paper
+                         1                       # Unreview Rejected Paper
+
+        expect(activity.papers.opened.size).to eq(opended_papers)
+      end
+    end
   end
 end


### PR DESCRIPTION
修正 #29 投稿統計問題，扣除放棄投稿的部分。
