### PR TITLE
Use puma and sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'pg'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'font-awesome-rails'
 gem 'pagedown-bootstrap-rails'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
@@ -31,6 +31,7 @@ gem 'acts-as-taggable-on'
 gem 'unicode_utils'
 gem 'scenic'
 gem 'slack-notifier'
+gem 'puma'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (2.0.5)
+    puma (3.10.0)
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
@@ -310,12 +311,17 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.6)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (1.11.4)
+      bundler
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sassc-rails (1.3.0)
+      railties (>= 4.0.0)
+      sass
+      sassc (~> 1.9)
+      sprockets (> 2.11)
+      sprockets-rails
+      tilt
     scenic (1.4.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -425,6 +431,7 @@ DEPENDENCIES
   passenger
   pg
   pry-rails
+  puma
   rails (>= 5.0.0.1)
   rails-controller-testing
   ratyrate
@@ -432,7 +439,7 @@ DEPENDENCIES
   redis-namespace
   rouge (~> 2.0.6)
   rspec-rails
-  sass-rails (~> 5.0)
+  sassc-rails
   scenic
   sdoc (~> 0.4.0)
   settingslogic
@@ -447,6 +454,5 @@ DEPENDENCIES
   unicode_utils
   web-console (~> 2.0)
 
-
 BUNDLED WITH
-   1.15.0
+   1.15.3

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Source Map
+  config.sass.inline_source_maps = true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
現在預設還是用 WEBrick 很慢，改成 Puma / Sassc 加快開發時啟動 Server 的速度。

>  啟用 Sassc 附加 Source Map 功能可以改善前端 Debug 速度。