### PR TITLE
Fix bug when click "Add Field" in edit activity

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -26,6 +26,7 @@ class Admin::ActivitiesController < Admin::ApplicationController
 
   def edit
     @activity = Activity.find_by(permalink: params[:id])
+    @new_custom_field = CustomField.new
     @new_notifier = Notifier.new
   end
 


### PR DESCRIPTION
Ensure only appear one field when click "Add Field" in edit activity