### PR TITLE
Update name and year in README and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 == README
 
-This is CFP App for [RubyConf Taiwan 2016](http://rubyconf.tw/2016) contributed by [members](https://github.com/5xRuby/rubyconftw-cfp/graphs/contributors) of [5xRuby](http://5xruby.tw).
+This is CFP App for [Ruby X Elixir Conf Taiwan](http://rubyconf.tw) contributed by [members](https://github.com/5xRuby/rubyconftw-cfp/graphs/contributors) of [5xRuby](http://5xruby.tw).
 
 ###Necessary Program
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="container">
     <ul class="footer-links">
-      <li><%= link_to "RubyConf 2016", "http://rubyconf.tw" %></li>
+      <li><%= link_to "Ruby X Elixir Conf Taiwan 2018", "http://2018.rubyconf.tw" %></li>
       <li><%= link_to "Twitter", "https://twitter.com/rubyconftw" %></li>
       <li><%= link_to "Contributors", contributors_path %></li>
     </ul>


### PR DESCRIPTION
I was working on a paper, and I noticed the footer still had a link to RubyConf 2016 (but the link actually led me to the new Ruby X Elixir Conf 2018 website.) I changed the footer link to use the new name and year, and did the same in the `README`. 🙂 

<img width="442" alt="screen shot 2017-10-09 at 15 29 33" src="https://user-images.githubusercontent.com/5259935/31340649-28deb4d8-ad07-11e7-8231-fcbee1e8f918.png">
